### PR TITLE
Add StegOnline to Tools.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,47 +1,48 @@
-| Name               | GitHub Link                     |
-| ------------------ | ------------------------------- |
-| Karan Sharma       | https://github.com/karanS08     |
-| Hussain Lohawala   | https://github.com/H9660        |
-| Kitton             | https://github.com/Kittonn      |
-| Sidharth V         | https://github.com/retr0ds      |
-| Anurag Roy         | https://github.com/AnuragRoy485 |
-| Sejal              | https://github.com/k1n0r4       |
-| zzril              | https://github.com/zzril        |
-| Samuuuh            | https://github.com/Samuuuh      |
-| Karan              | https://github.com/Ye8i         |
-| Arn                | https://github.com/arn355       |
-| Anant Kumar Mathur | https://github.com/anant2003    |
-| Skul1CrowN         | https://github.com/Skul1CrowN   |
-| Barw               | https://github.com/BarwSirati   |
-| Jaammeesss         | https://github.com/Jaammeesss   |
-| Rishi Goswami      | https://github.com/rishig2003   |
-| Shivam Jaiswal     | http://github.com/Shivaminc     |
-| vivek gorasiya     | https://github.com/vivek0033    |
-| rdmchr             | https://github.com/rdmchr       |
-| Sooki              | https://github.com/0xSooki      |
-| Exit-Guy           | https://github.com/exithere     |
-| Poomipat-Ch        | https://github.com/Poomipat-Ch  |
-| Shyam Sunder S     | https://github.com/ShyamSunder149|
-| Amdjedbens | https://github.com/amdjedbens |
-| nga1hte | https://github.com/nga1hte |
-| Mohd Shahil | https://github.com/Shahil2002 |
-| Soumik Seal | https://github.com/Soumik8114 |
-| Akshat Kushwaha | https://github.com/Akshat-02 |
-| Madhav Saini       | https://github.com/FireNdIce3 |
-| mind8hunter | https://github.com/mind8hunter |
-| Som Chandra | https://github.com/Somchandra17 |
-| aph | https://github.com/aphkyle/ |
-| Dhiraj Gilda | https://github.com/DhirajGilda |
-|Muhammad Ahsan Siddiqui| https://github.com/ahsansiddiqui2|
-| Z3RO_O             | https://github.com/Z3RO-O       |
-| komen205             | https://github.com/komen205       |
-| Tejas             | https://github.com/MrTejas       |
-| Mukund            | https://github.com/Mukund32      |
-| Vikas Anand            | https://github.com/kingcoolvikas      |
-| Haidar Rifki | https://github.com/haidarrifki |
-| Biswajit Sahoo | https://github.com/BiswajitSahoo-tech |
-| Bourbxn          | https://github.com/Bourbxn |
-| Abhishek Kumar Roy | https://github.com/Adi-Abhishek |
-| mirusu400 | https://github.com/mirusu400 |
-| Chinmay | https://github.com/chinmayayy |
-| Nishant | https://github.com/Nishantjain10 |
+| Name                    | GitHub Link                           |
+|-------------------------|---------------------------------------|
+| Karan Sharma            | https://github.com/karanS08           |
+| Hussain Lohawala        | https://github.com/H9660              |
+| Kitton                  | https://github.com/Kittonn            |
+| Sidharth V              | https://github.com/retr0ds            |
+| Anurag Roy              | https://github.com/AnuragRoy485       |
+| Sejal                   | https://github.com/k1n0r4             |
+| zzril                   | https://github.com/zzril              |
+| Samuuuh                 | https://github.com/Samuuuh            |
+| Karan                   | https://github.com/Ye8i               |
+| Arn                     | https://github.com/arn355             |
+| Anant Kumar Mathur      | https://github.com/anant2003          |
+| Skul1CrowN              | https://github.com/Skul1CrowN         |
+| Barw                    | https://github.com/BarwSirati         |
+| Jaammeesss              | https://github.com/Jaammeesss         |
+| Rishi Goswami           | https://github.com/rishig2003         |
+| Shivam Jaiswal          | http://github.com/Shivaminc           |
+| vivek gorasiya          | https://github.com/vivek0033          |
+| rdmchr                  | https://github.com/rdmchr             |
+| Sooki                   | https://github.com/0xSooki            |
+| Exit-Guy                | https://github.com/exithere           |
+| Poomipat-Ch             | https://github.com/Poomipat-Ch        |
+| Shyam Sunder S          | https://github.com/ShyamSunder149     |
+| Amdjedbens              | https://github.com/amdjedbens         |
+| nga1hte                 | https://github.com/nga1hte            |
+| Mohd Shahil             | https://github.com/Shahil2002         |
+| Soumik Seal             | https://github.com/Soumik8114         |
+| Akshat Kushwaha         | https://github.com/Akshat-02          |
+| Madhav Saini            | https://github.com/FireNdIce3         |
+| mind8hunter             | https://github.com/mind8hunter        |
+| Som Chandra             | https://github.com/Somchandra17       |
+| aph                     | https://github.com/aphkyle/           |
+| Dhiraj Gilda            | https://github.com/DhirajGilda        |
+| Muhammad Ahsan Siddiqui | https://github.com/ahsansiddiqui2     |
+| Z3RO_O                  | https://github.com/Z3RO-O             |
+| komen205                | https://github.com/komen205           |
+| Tejas                   | https://github.com/MrTejas            |
+| Mukund                  | https://github.com/Mukund32           |
+| Vikas Anand             | https://github.com/kingcoolvikas      |
+| Haidar Rifki            | https://github.com/haidarrifki        |
+| Biswajit Sahoo          | https://github.com/BiswajitSahoo-tech |
+| Bourbxn                 | https://github.com/Bourbxn            |
+| Abhishek Kumar Roy      | https://github.com/Adi-Abhishek       |
+| mirusu400               | https://github.com/mirusu400          |
+| Chinmay                 | https://github.com/chinmayayy         |
+| Nishant                 | https://github.com/Nishantjain10      |
+| FluxCapacitor2          | https://github.com/FluxCapacitor2     |

--- a/Tools.md
+++ b/Tools.md
@@ -60,6 +60,7 @@
 | DTMF decoder | Forensics | https://unframework.github.io/dtmf-detect/ | Tool to solve DTMF audio based forensics |
 | Dislocker |  Forensics | http://www.hsc.fr/ressources/outils/dislocker/ | Tool for reading Bitlocker encrypted partitions. |
 | Firmware-mod-kit | Forensics | https://code.google.com/p/firmware-mod-kit/ | Tools for firmware packing/unpacking. |
+| StegOnline | Forensics | https://stegonline.georgeom.net/ | [Steganography](https://en.wikipedia.org/wiki/Steganography) tool for extracting embedded data from images. A web-based, accessible and open-source port of StegSolve. |
 
 <br>
 


### PR DESCRIPTION
StegOnline (https://stegonline.georgeom.net) is an online tool for searching images for embedded data. It is useful for [steganography](https://en.wikipedia.org/wiki/Steganography) and forensics CTF challenges when a file is known to be an image.

*The diff for CONTRIBUTORS.md may look large, but this is because I reformatted the Markdown table. No entries were actually changed except for the addition at the end.*